### PR TITLE
zoning is needed for motif occultation

### DIFF
--- a/src/tcom/batch/normalization/normalization.ts
+++ b/src/tcom/batch/normalization/normalization.ts
@@ -23,6 +23,7 @@ import { logger } from '../../../library/logger'
 
 import { strict as assert } from 'assert'
 import { annotateDecision } from '../../../library/nlp/annotation'
+import { ZoningApiService } from './services/zoningApi.service'
 
 const dbSderApiGateway = new DbSderApiGateway()
 const bucketNameIntegre = process.env.S3_BUCKET_NAME_RAW_TCOM
@@ -43,6 +44,8 @@ export async function normalizationJob(
 
   const listConvertedDecision: ConvertedDecisionWithMetadonneesDto[] = []
   const s3Repository = new DecisionS3Repository()
+
+  const zoningApiService: ZoningApiService = new ZoningApiService()
 
   const decisionList = (await fetchDecisionListFromS3(s3Repository, limit)).filter((name) =>
     name.endsWith('.json')
@@ -159,6 +162,17 @@ export async function normalizationJob(
         decision.metadonnees,
         decisionFilename
       )
+
+      try {
+        decisionToSave.originalTextZoning = await zoningApiService.getDecisionZoning(decisionToSave)
+      } catch (error) {
+        logger.error({
+          operations: ['normalization', `normalizationJob-TCOM-${jobId}`],
+          path: 'src/tcom/batch/normalization/normalization.ts',
+          message: `Error while calling zoning. Error : ${error}`
+        })
+      }
+
       decisionToSave.labelStatus = await computeLabelStatus(decisionToSave)
       decisionToSave.occultation = {
         additionalTerms: '',

--- a/src/tcom/batch/normalization/services/computeLabelStatus.ts
+++ b/src/tcom/batch/normalization/services/computeLabelStatus.ts
@@ -60,34 +60,23 @@ export async function computeLabelStatus(
     return LabelStatus.IGNORED_DEBAT_NON_PUBLIC
   }
 
-  try {
-    const decisionZoning: UnIdentifiedDecisionTcom['zoning'] =
-      await zoningApiService.getDecisionZoning(decisionDto)
-    decisionDto.originalTextZoning = decisionZoning
-    if (decisionZoning.is_public === 0) {
-      logger.error({
-        ...formatLogs,
-        msg: `Decision is not public *according to Zoning*. Changing LabelStatus to ${LabelStatus.IGNORED_DECISION_NON_PUBLIQUE_PAR_ZONAGE}.`,
-        idJuridiction: decisionDto.jurisdictionId,
-        libelleJuridiction: decisionDto.jurisdictionName
-      })
-      return LabelStatus.IGNORED_DECISION_NON_PUBLIQUE_PAR_ZONAGE
-    }
-    if (decisionZoning.is_public === 2) {
-      logger.error({
-        ...formatLogs,
-        msg: `Decision debates are not public *according to Zoning*. Changing LabelStatus to ${LabelStatus.IGNORED_DECISION_PARTIELLEMENT_PUBLIQUE_PAR_ZONAGE}.`,
-        idJuridiction: decisionDto.jurisdictionId,
-        libelleJuridiction: decisionDto.jurisdictionName
-      })
-      return LabelStatus.IGNORED_DECISION_PARTIELLEMENT_PUBLIQUE_PAR_ZONAGE
-    }
-  } catch (error) {
+  if (decisionDto.originalTextZoning.is_public === 0) {
     logger.error({
       ...formatLogs,
-      msg: `Error while calling zoning.`,
-      data: error
+      msg: `Decision is not public *according to Zoning*. Changing LabelStatus to ${LabelStatus.IGNORED_DECISION_NON_PUBLIQUE_PAR_ZONAGE}.`,
+      idJuridiction: decisionDto.jurisdictionId,
+      libelleJuridiction: decisionDto.jurisdictionName
     })
+    return LabelStatus.IGNORED_DECISION_NON_PUBLIQUE_PAR_ZONAGE
+  }
+  if (decisionDto.originalTextZoning.is_public === 2) {
+    logger.error({
+      ...formatLogs,
+      msg: `Decision debates are not public *according to Zoning*. Changing LabelStatus to ${LabelStatus.IGNORED_DECISION_PARTIELLEMENT_PUBLIQUE_PAR_ZONAGE}.`,
+      idJuridiction: decisionDto.jurisdictionId,
+      libelleJuridiction: decisionDto.jurisdictionName
+    })
+    return LabelStatus.IGNORED_DECISION_PARTIELLEMENT_PUBLIQUE_PAR_ZONAGE
   }
 
   /*


### PR DESCRIPTION
Aujourd'hui une décision dont il faut occulter les motifs échoue au niveau de l'annotation car le zonage sur l'originalText n'est pas ajouté a la décision.

En attente de la validation des nouvelles règles de filtrage des TCOM pour déployer ce correctif.